### PR TITLE
Add `@` character to the sanitized characters list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.8 - 02 Apr 2026
+* Add `@` character to the sanitized characters list
+
 ## 2.0.7 - 20 Sept 2022
 * Non Latin characters in filename are handled
 

--- a/bea-sanitize-filename.php
+++ b/bea-sanitize-filename.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: BEA - Sanitize Filename
-Version: 2.0.7
+Version: 2.0.8
 Plugin URI: https://github.com/BeAPI/bea-sanitize-filename
 Description: Remove all punctuation and accents from the filename of uploaded files.
 Author: Be API
@@ -38,7 +38,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 function bea_sanitize_file_name_chars( $special_chars = array() ) {
 	// Special caracters
-	$special_chars = array_merge( array( '’', '‘', '“', '”', '«', '»', '‹', '›', '—', '€', '©' ), $special_chars );
+	$special_chars = array_merge( array( ‘’’, ‘’’, ‘”’, ‘”’, ‘«’, ‘»’, ‘‹’, ‘›’, ‘—‘, ‘€’, ‘©’, ‘@’ ), $special_chars );
 	/**
 	 * Accentued caracters
 	 * @see   https://github.com/BeAPI/bea-sanitize-filename/issues/8

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: uploads, sanitize, media
 Requires at least: 4.0
 Requires php: 5.6
 Tested up to: 6.1
-Stable tag: 2.0.7
+Stable tag: 2.0.8
 License: GPLv3 or later
 License URI: https://github.com/BeAPI/bea-sanitize-filename/blob/master/LICENSE.md
 
@@ -57,6 +57,9 @@ Yes.
 You just need to activate on each site.
 
 == Changelog ==
+
+= 2.0.8 - 02 Apr 2026 =
+- Add `@` character to the sanitized characters list
 
 = 2.0.7 - 20 Sept 2022 =
 - Non Latin characters in filename are handled


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Small change to filename sanitization plus version bump, but it touches the core `sanitize_file_name_chars` filter and the updated special-character array appears to include non-ASCII quote characters that could cause a PHP parse/fatal error if committed as-is.
> 
> **Overview**
> Adds `@` to the plugin’s sanitized character list applied via `sanitize_file_name_chars`, so uploaded filenames will strip/replace `@`.
> 
> Bumps plugin metadata and documentation to `2.0.8` and updates `CHANGELOG.md`/`readme.txt` with the new release entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cefdc398e3c05deaec35b0d6644f6974acd084b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->