### PR TITLE
Fix filename extension stripping bug and clean up dev tooling

### DIFF
--- a/bea-sanitize-filename.php
+++ b/bea-sanitize-filename.php
@@ -75,7 +75,7 @@ function bea_sanitize_file_name( $file_name = '' ) {
 	$ext = pathinfo( $file_name, PATHINFO_EXTENSION );
 
 	// No extension, go out ?
-	if ( empty( $ext ) ) {
+	if ( $ext === '' ) {
 		return $file_name;
 	}
 

--- a/bea-sanitize-filename.php
+++ b/bea-sanitize-filename.php
@@ -33,21 +33,21 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
 /**
- * Add some special chats to espace to WordPress basic list
+ * Add some special chars to escape to WordPress basic list
  *
  * @param array $special_chars
  *
  * @return array
  */
 function bea_sanitize_file_name_chars( $special_chars = array() ) {
-	// Special caracters
-	$special_chars = array_merge( array( '’', '‘', '”', '“', '«', '»', '‹', '›', '—', '€', '©', '@' ), $special_chars );
+	// Special characters
+	$special_chars = array_merge( array( ‘’’, ‘’’, ‘”’, ‘”’, ‘«’, ‘»’, ‘‹’, ‘›’, ‘—‘, ‘€’, ‘©’, ‘@’ ), $special_chars );
 	/**
-	 * Accentued caracters
+	 * Accented characters
 	 * @see   https://github.com/BeAPI/bea-sanitize-filename/issues/8
 	 * @since 2.0.6
 	 */
-	$special_chars = array_merge( array( 'À', 'Á', 'Â', 'Ã', 'Ä', 'Å', 'Ç', 'È', 'É', 'Ê', 'Ë', 'Ì', 'Í', 'Î', 'Ï', 'Ò', 'Ó', 'Ô', 'Õ', 'Ö', 'Ù', 'Ú', 'Û', 'Ü', 'Ý', 'à', 'á', 'â', 'ã', 'ä', 'å', 'ç', 'è', 'é', 'ê', 'ë', 'ì', 'í', 'î', 'ï', 'ð', 'ò', 'ó', 'ô', 'õ', 'ö', 'ù', 'ú', 'û', 'ü', 'ý', 'ÿ' ), $special_chars );
+	$special_chars = array_merge( array( ‘À’, ‘Á’, ‘Â’, ‘Ã’, ‘Ä’, ‘Å’, ‘Ç’, ‘È’, ‘É’, ‘Ê’, ‘Ë’, ‘Ì’, ‘Í’, ‘Î’, ‘Ï’, ‘Ò’, ‘Ó’, ‘Ô’, ‘Õ’, ‘Ö’, ‘Ù’, ‘Ú’, ‘Û’, ‘Ü’, ‘Ý’, ‘à’, ‘á’, ‘â’, ‘ã’, ‘ä’, ‘å’, ‘ç’, ‘è’, ‘é’, ‘ê’, ‘ë’, ‘ì’, ‘í’, ‘î’, ‘ï’, ‘ð’, ‘ò’, ‘ó’, ‘ô’, ‘õ’, ‘ö’, ‘ù’, ‘ú’, ‘û’, ‘ü’, ‘ý’, ‘ÿ’ ), $special_chars );
 
 	return $special_chars;
 }
@@ -71,19 +71,16 @@ function bea_sanitize_file_name( $file_name = '' ) {
 		return $file_name;
 	}
 
-	// get extension
-	preg_match( '/\.[^\.]+$/i', $file_name, $ext );
+	// Separate filename and extension
+	$ext = pathinfo( $file_name, PATHINFO_EXTENSION );
 
 	// No extension, go out ?
-	if ( ! isset( $ext[0] ) ) {
+	if ( empty( $ext ) ) {
 		return $file_name;
 	}
 
-	// Get only first part
-	$ext = $ext[0];
-
 	// work only on the filename without extension
-	$file_name = str_replace( $ext, '', $file_name );
+	$file_name = substr( $file_name, 0, -( strlen( $ext ) + 1 ) );
 
 	// only lowercase
 	$file_name = mb_strtolower( $file_name );
@@ -94,7 +91,7 @@ function bea_sanitize_file_name( $file_name = '' ) {
 	$file_name = str_replace( '_', '-', $file_name );
 
 	// Return sanitized file name
-	return $file_name . $ext;
+	return $file_name . '.' . $ext;
 }
 
 add_filter( 'sanitize_file_name', 'bea_sanitize_file_name', 10, 1 );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -44,7 +44,7 @@
   <config name="minimum_supported_wp_version" value="4.4"/>
 
   <rule ref="PHPCompatibility"/>
-  <config name="testVersion" value="5.6-"/>
+  <config name="testVersion" value="8.0-"/>
 
   <rule ref="WordPress.WP.I18n">
     <properties>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,9 +2,6 @@
 	bootstrap="tests/bootstrap.php"
 	backupGlobals="false"
 	colors="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
 	>
 	<testsuites>
 		<testsuite name="unit">

--- a/tests/wpunit/SanitizeFilenameTest.php
+++ b/tests/wpunit/SanitizeFilenameTest.php
@@ -30,7 +30,7 @@ class SanitizeFilenameTest extends TestCase {
 		$this->assertSame( $out, sanitize_file_name( $in ) );
 	}
 
-	public function test_convert_at_sign_to_dashes() {
+	public function test_remove_at_sign() {
 		$in  = 'filename@with@arobase.jpg';
 		$out = 'filenamewitharobase.jpg';
 		$this->assertSame( $out, sanitize_file_name( $in ) );


### PR DESCRIPTION
## Summary

The main fix: `str_replace($ext, '', $file_name)` stripped every occurrence of the extension string from the filename, not just the suffix. Example: `css.style.css` became `style` instead of `css.style`. Fixed with `pathinfo()` + `substr()`.

Since I was in there anyway, I cleaned up a few things that were bugging me:

- PHPCompatibility `testVersion` was set to `5.6-` but the plugin requires PHP 8.0+. Updated to `8.0-`.
- Removed the `convert*ToExceptions` attributes from PHPUnit config (deprecated in 9.5, gone in 10).
- Fixed typos in comments ("chats" → "chars", "caracters" → "characters") and renamed `test_convert_at_sign_to_dashes` to `test_remove_at_sign`, since the `@` is stripped, not converted to a dash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core upload filename sanitization and updates the special-character lists; the latter introduces non-standard quote characters that could cause parsing/runtime issues if not intentional. Also updates PHP compatibility/testing configs, which may affect CI outcomes.
> 
> **Overview**
> Fixes a filename extension handling bug in `bea_sanitize_file_name()` by switching from regex/`str_replace()` to `pathinfo()` + `substr()` so only the trailing extension is removed and then re-appended.
> 
> Updates the set of characters escaped by `bea_sanitize_file_name_chars()` and cleans up related comments, but also changes the quoting of these literals (now using typographic quotes), which may alter behavior or even break parsing if unintended.
> 
> Modernizes dev tooling by bumping `PHPCompatibility` to `8.0-` in `phpcs.xml`, removing deprecated PHPUnit `convert*ToExceptions` flags, and renaming a unit test to reflect that `@` is removed rather than converted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59b8e05d3a657891d57fb1b8ff19fccab7f1f1d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->